### PR TITLE
BaSP-TG-104: password joi validation fixed

### DIFF
--- a/src/validations/admins.js
+++ b/src/validations/admins.js
@@ -7,7 +7,7 @@ const adminValidationCreate = (req, res, next) => {
     email: Joi.string().email().required(),
     gender: Joi.string().valid('male', 'female', 'polygender').required(),
     active: Joi.boolean().required(),
-    password: Joi.string().min(3).max(8).required(),
+    password: Joi.string().min(8).required(),
   });
   const validation = schemaConditions.validate(req.body);
   if (validation.error) {


### PR DESCRIPTION
The password in joi validations has a maximum of 8 characters when it should be a minimum